### PR TITLE
Feat: Network Rule

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.atomicfu)
                 implementation(libs.multiplatform.settings)
-                implementation(libs.konnection)
             }
         }
         val commonTest by getting {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.atomicfu)
                 implementation(libs.multiplatform.settings)
+                implementation(libs.konnection)
             }
         }
         val commonTest by getting {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,6 @@ dependencyResolutionManagement {
             library("roboelectric", "org.robolectric", "robolectric").version("4.5.1")
             library("multiplatform-settings", "com.russhwolf", "multiplatform-settings").version("1.0.0-RC")
             library("multiplatform-settings-test", "com.russhwolf", "multiplatform-settings-test").version("1.0.0-RC")
-            library("konnection", "dev.tmapps", "konnection").version("1.1.10")
             plugin("versioning", "net.nemerosa.versioning").version("3.0.0")
             plugin("kotlin.serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ dependencyResolutionManagement {
             library("roboelectric", "org.robolectric", "robolectric").version("4.5.1")
             library("multiplatform-settings", "com.russhwolf", "multiplatform-settings").version("1.0.0-RC")
             library("multiplatform-settings-test", "com.russhwolf", "multiplatform-settings-test").version("1.0.0-RC")
+            library("konnection", "dev.tmapps", "konnection").version("1.1.10")
             plugin("versioning", "net.nemerosa.versioning").version("3.0.0")
             plugin("kotlin.serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
         }

--- a/src/androidMain/AndroidManifest.xml
+++ b/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.liftric.job.queue">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/src/androidMain/kotlin/com/liftric/job/queue/JobQueue.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/JobQueue.kt
@@ -8,9 +8,13 @@ actual class JobQueue(
     context: Context,
     serializers: SerializersModule = SerializersModule {},
     configuration: Queue.Configuration = Queue.DefaultConfiguration,
-    store: JsonStorage = SettingsStorage(SharedPreferencesSettings.Factory(context).create("com.liftric.persisted.queue"))
+    networkListener: NetworkListener,
+    store: JsonStorage = SettingsStorage(
+        SharedPreferencesSettings.Factory(context).create("com.liftric.persisted.queue")
+    )
 ) : AbstractJobQueue(
-    serializers,
-    configuration,
-    store
+    serializers = serializers,
+    networkListener = networkListener,
+    configuration = configuration,
+    store = store
 )

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,29 +1,28 @@
 package com.liftric.job.queue
 
-import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 actual class NetworkListener(
-    val context: Context,
+    networkManager: NetworkManager,
     scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
 ) : AbstractNetworkListener(
+    networkManager = networkManager,
     scope = scope
 ) {
-    private val _currentNetworkState = MutableSharedFlow<NetworkState>(replay = 1)
-    override val currentNetworkState: SharedFlow<NetworkState>
-        get() = _currentNetworkState.asSharedFlow()
+    private val _currentNetworkState = MutableStateFlow(NetworkState.NONE)
+    override val currentNetworkState: StateFlow<NetworkState>
+        get() = _currentNetworkState.asStateFlow()
 
     override fun observeNetworkState() {
         scope.launch {
-            NetworkManager(context)
+            networkManager
                 .observeNetworkConnection()
-                .collectLatest { currentNetworkState ->
+                .collect { currentNetworkState ->
                     _currentNetworkState.emit(
                         when (currentNetworkState) {
                             NetworkState.NONE -> NetworkState.NONE

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,11 +1,9 @@
 package com.liftric.job.queue
 
 import android.content.Context
-import com.liftric.job.queue.rules.NetworkState
-import dev.tmapps.konnection.Konnection
-import dev.tmapps.konnection.NetworkConnection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 actual class NetworkListener(
@@ -15,15 +13,19 @@ actual class NetworkListener(
 ) {
     actual fun observeNetworkState() {
         scope.launch {
-            Konnection(context = context)
+            NetworkManager(context)
                 .observeNetworkConnection()
-                .collect { networkConnection ->
-                    networkState = when (networkConnection) {
-                        NetworkConnection.WIFI -> NetworkState.WIFI
-                        NetworkConnection.MOBILE -> NetworkState.MOBILE
+                .collectLatest { currentNetworkState ->
+                    networkState = when (currentNetworkState) {
+                        NetworkState.NONE -> NetworkState.NONE
+                        NetworkState.MOBILE -> NetworkState.MOBILE
+                        NetworkState.WIFI -> NetworkState.WIFI
                         null -> NetworkState.NONE
                     }
                 }
         }
     }
+
+    // not needed for Android
+    actual fun stopMonitoring() {}
 }

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -3,29 +3,40 @@ package com.liftric.job.queue
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 actual class NetworkListener(
     val context: Context,
-    actual var networkState: NetworkState = NetworkState.NONE,
-    actual val scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
+    scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
+) : AbstractNetworkListener(
+    scope = scope
 ) {
-    actual fun observeNetworkState() {
+    private val _currentNetworkState = MutableSharedFlow<NetworkState>(replay = 1)
+    override val currentNetworkState: SharedFlow<NetworkState>
+        get() = _currentNetworkState.asSharedFlow()
+
+    override fun observeNetworkState() {
         scope.launch {
             NetworkManager(context)
                 .observeNetworkConnection()
                 .collectLatest { currentNetworkState ->
-                    networkState = when (currentNetworkState) {
-                        NetworkState.NONE -> NetworkState.NONE
-                        NetworkState.MOBILE -> NetworkState.MOBILE
-                        NetworkState.WIFI -> NetworkState.WIFI
-                        null -> NetworkState.NONE
-                    }
+                    _currentNetworkState.emit(
+                        when (currentNetworkState) {
+                            NetworkState.NONE -> NetworkState.NONE
+                            NetworkState.MOBILE -> NetworkState.MOBILE
+                            NetworkState.WIFI -> NetworkState.WIFI
+                            null -> NetworkState.NONE
+                        }
+                    )
                 }
         }
     }
 
+
     // not needed for Android
-    actual fun stopMonitoring() {}
+    override fun stopMonitoring() {}
 }

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,0 +1,29 @@
+package com.liftric.job.queue
+
+import android.content.Context
+import com.liftric.job.queue.rules.NetworkState
+import dev.tmapps.konnection.Konnection
+import dev.tmapps.konnection.NetworkConnection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+actual class NetworkListener(
+    val context: Context,
+    actual var networkState: NetworkState = NetworkState.NONE,
+    actual val scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
+) {
+    actual fun observeNetworkState() {
+        scope.launch {
+            Konnection(context = context)
+                .observeNetworkConnection()
+                .collect { networkConnection ->
+                    networkState = when (networkConnection) {
+                        NetworkConnection.WIFI -> NetworkState.WIFI
+                        NetworkConnection.MOBILE -> NetworkState.MOBILE
+                        null -> NetworkState.NONE
+                    }
+                }
+        }
+    }
+}

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
@@ -1,5 +1,6 @@
 package com.liftric.job.queue
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.net.ConnectivityManager
@@ -8,6 +9,7 @@ import android.os.Build
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+@SuppressLint("MissingPermission")
 actual class NetworkManager(context: Context) {
     private var connectivityManager: ConnectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
@@ -15,8 +15,7 @@ actual class NetworkManager(context: Context) {
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     private val connectionPublisher = MutableStateFlow(getCurrentNetworkConnection())
-
-    fun observeNetworkConnection(): Flow<NetworkState?> = connectionPublisher
+    val network: Flow<NetworkState?> = connectionPublisher
 
     private fun getCurrentNetworkConnection(): NetworkState? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
+++ b/src/androidMain/kotlin/com/liftric/job/queue/NetworkManager.kt
@@ -1,0 +1,53 @@
+package com.liftric.job.queue
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+actual class NetworkManager(context: Context) {
+    private var connectivityManager: ConnectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val connectionPublisher = MutableStateFlow(getCurrentNetworkConnection())
+
+    fun observeNetworkConnection(): Flow<NetworkState?> = connectionPublisher
+
+    private fun getCurrentNetworkConnection(): NetworkState? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            postAndroidMNetworkConnection(connectivityManager)
+        } else {
+            preAndroidMNetworkConnection(connectivityManager)
+        }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private fun postAndroidMNetworkConnection(connectivityManager: ConnectivityManager): NetworkState? {
+        val network = connectivityManager.activeNetwork
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
+        return getNetworkConnection(capabilities)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun preAndroidMNetworkConnection(connectivityManager: ConnectivityManager): NetworkState? =
+        when (connectivityManager.activeNetworkInfo?.type) {
+            null -> null
+            ConnectivityManager.TYPE_WIFI -> NetworkState.WIFI
+            else -> NetworkState.MOBILE
+        }
+
+    private fun getNetworkConnection(capabilities: NetworkCapabilities?): NetworkState? =
+        when {
+            capabilities == null -> null
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.M
+                    && !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) -> null
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                    !(capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) -> null
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> NetworkState.WIFI
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> NetworkState.MOBILE
+            else -> null
+        }
+}

--- a/src/androidTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/androidTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -16,7 +16,9 @@ actual class JobQueueTests : AbstractJobQueueTests(
             }
         },
         store = MapStorage(),
-        networkListener = NetworkListener(context = InstrumentationRegistry.getInstrumentation().context)
+        networkListener = NetworkListener(
+            networkManager = NetworkManager(InstrumentationRegistry.getInstrumentation().context)
+        )
     )
 )
 

--- a/src/androidTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/androidTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -7,12 +7,16 @@ import kotlinx.serialization.modules.polymorphic
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-actual class JobQueueTests: AbstractJobQueueTests(JobQueue(
-    context = InstrumentationRegistry.getInstrumentation().targetContext,
-    serializers = SerializersModule {
-        polymorphic(Task::class) {
-            subclass(TestTask::class, TestTask.serializer())
-        }
-    },
-    store = MapStorage()
-))
+actual class JobQueueTests : AbstractJobQueueTests(
+    JobQueue(
+        context = InstrumentationRegistry.getInstrumentation().targetContext,
+        serializers = SerializersModule {
+            polymorphic(Task::class) {
+                subclass(TestTask::class, TestTask.serializer())
+            }
+        },
+        store = MapStorage(),
+        networkListener = NetworkListener(context = InstrumentationRegistry.getInstrumentation().context)
+    )
+)
+

--- a/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
@@ -1,6 +1,5 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.datetime.Clock

--- a/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
@@ -31,13 +31,10 @@ data class Job(
 
     private var canRepeat: Boolean = true
 
-    suspend fun run(currentNetworkState: NetworkState): JobEvent {
+    suspend fun run(): JobEvent {
         val event = try {
             info.rules.forEach {
-                it.willRun(
-                    context = this@Job,
-                    currentNetworkState = currentNetworkState
-                )
+                it.willRun(context = this@Job)
             }
             task.body()
             JobEvent.DidSucceed(this@Job)

--- a/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/Job.kt
@@ -1,10 +1,8 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkException
 import com.liftric.job.queue.rules.NetworkState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
@@ -35,34 +33,30 @@ data class Job(
     private var canRepeat: Boolean = true
 
     suspend fun run(currentNetworkState: NetworkState): JobEvent {
-        return withTimeout(info.timeout) {
-            val event = try {
-                info.rules.forEach { it.willRun(this@Job) }
-                if (info.minRequiredNetworkState <= currentNetworkState) {
-                    println("NETWORK: satisfied")
-                    task.body()
-                    JobEvent.DidSucceed(this@Job)
-                } else {
-                    println("NETWORK: unsatisfied")
-                    throw NetworkException("Network requirement not satisfied!")
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                canRepeat = task.onRepeat(e)
-                JobEvent.DidFail(this@Job, e)
+        val event = try {
+            info.rules.forEach {
+                it.willRun(
+                    context = this@Job,
+                    currentNetworkState = currentNetworkState
+                )
             }
-
-            try {
-                info.rules.forEach { it.willRemove(this@Job, event) }
-
-                event
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                JobEvent.DidFailOnRemove(this@Job, e)
-            }
+            task.body()
+            JobEvent.DidSucceed(this@Job)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            canRepeat = task.onRepeat(e)
+            JobEvent.DidFail(this@Job, e)
         }
+
+        try {
+            info.rules.forEach { it.willRemove(this@Job, event) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            JobEvent.DidFailOnRemove(this@Job, e)
+        }
+        return event
     }
 
     override suspend fun cancel() {

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobContext.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobContext.kt
@@ -2,9 +2,14 @@ package com.liftric.job.queue
 
 import kotlinx.datetime.Instant
 
-interface JobContext: JobData {
+interface JobContext : JobData {
     suspend fun cancel()
-    suspend fun repeat(id: UUID = this.id, info: JobInfo = this.info, task: Task = this.task, startTime: Instant = this.startTime)
+    suspend fun repeat(
+        id: UUID = this.id,
+        info: JobInfo = this.info,
+        task: Task = this.task,
+        startTime: Instant = this.startTime,
+    )
 }
 
 interface JobData {

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobEvent.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobEvent.kt
@@ -10,4 +10,7 @@ sealed class JobEvent {
     data class ShouldRepeat(val job: Job): JobEvent()
     data class DidCancel(val job: JobContext): JobEvent()
     data class DidFailOnRemove(val job: JobContext, val error: Throwable): JobEvent()
+    data class NetworkRuleSatisfied(val job: JobContext): JobEvent()
+    data class NetworkRuleTimeout(val job: JobContext): JobEvent()
+    data class JobTimeout(val job: JobContext): JobEvent()
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
@@ -1,6 +1,5 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkState
 import kotlin.time.Duration
 import kotlinx.serialization.Serializable
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
@@ -1,5 +1,6 @@
 package com.liftric.job.queue
 
+import com.liftric.job.queue.rules.NetworkState
 import kotlin.time.Duration
 import kotlinx.serialization.Serializable
 
@@ -8,5 +9,6 @@ data class JobInfo(
     var tag: String? = null,
     var timeout: Duration = Duration.INFINITE,
     var rules: MutableList<JobRule> = mutableListOf(),
-    var shouldPersist: Boolean = false
+    var shouldPersist: Boolean = false,
+    var minRequiredNetworkState: NetworkState = NetworkState.NONE
 )

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobInfo.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class JobInfo(
     var tag: String? = null,
-    var timeout: Duration = Duration.INFINITE,
+    var jobTimeout: Duration = Duration.INFINITE,
+    var networkRuleTimeout: Duration = Duration.INFINITE,
     var rules: MutableList<JobRule> = mutableListOf(),
     var shouldPersist: Boolean = false,
     var minRequiredNetworkState: NetworkState = NetworkState.NONE

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
@@ -155,6 +155,7 @@ abstract class AbstractJobQueue(
                         if(e is TimeoutCancellationException) {
                             println("Timeout exceeded")
                         }
+                        networkListener.stopMonitoring()
                         jobEventListener.emit(JobEvent.DidCancel(job))
                     } finally {
                         if (job.info.shouldPersist) {

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
@@ -147,7 +147,7 @@ abstract class AbstractJobQueue(
                     try {
                         var shouldRunJob = false
                         try {
-                            withTimeout(15.seconds) NetworkRuleTimeout@{
+                            withTimeout(job.info.networkRuleTimeout) NetworkRuleTimeout@{
                                 networkListener.currentNetworkState.collect { currentNetworkState ->
                                     val isNetworkRuleSatisfied =
                                         networkListener.isNetworkRuleSatisfied(
@@ -164,7 +164,7 @@ abstract class AbstractJobQueue(
                         } catch (e: CancellationException) {
                             if (shouldRunJob) {
                                 jobEventListener.emit(JobEvent.WillRun(job))
-                                withTimeout(job.info.timeout) {
+                                withTimeout(job.info.jobTimeout) {
                                     val result = job.run()
                                     jobEventListener.emit(result)
                                 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobQueue.kt
@@ -147,6 +147,7 @@ abstract class AbstractJobQueue(
                 job.delegate = delegate
                 running.value[job.id] = configuration.scope.launch {
                     try {
+                        networkListener.observeNetworkState()
                         var shouldRunJob = false
                         try {
                             withTimeout(job.info.networkRuleTimeout) NetworkRuleTimeout@{

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
@@ -7,6 +7,6 @@ abstract class JobRule {
     open suspend fun mutating(info: JobInfo) {}
     @Throws(Throwable::class)
     open suspend fun willSchedule(queue: Queue, context: JobContext) {}
-    open suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {}
+    open suspend fun willRun(context: JobContext) {}
     open suspend fun willRemove(context: JobContext, result: JobEvent) {}
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
@@ -4,9 +4,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 abstract class JobRule {
-    open suspend fun mutating(info: JobInfo) {}
+    open suspend fun mutating(jobInfo: JobInfo) {}
     @Throws(Throwable::class)
-    open suspend fun willSchedule(queue: Queue, context: JobContext) {}
-    open suspend fun willRun(context: JobContext) {}
-    open suspend fun willRemove(context: JobContext, result: JobEvent) {}
+    open suspend fun willSchedule(queue: Queue, jobContext: JobContext) {}
+    open suspend fun willRun(jobContext: JobContext) {}
+    open suspend fun willRemove(jobContext: JobContext, result: JobEvent) {}
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
@@ -1,6 +1,5 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkState
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/JobRule.kt
@@ -1,5 +1,6 @@
 package com.liftric.job.queue
 
+import com.liftric.job.queue.rules.NetworkState
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -7,6 +8,6 @@ abstract class JobRule {
     open suspend fun mutating(info: JobInfo) {}
     @Throws(Throwable::class)
     open suspend fun willSchedule(queue: Queue, context: JobContext) {}
-    open suspend fun willRun(context: JobContext) {}
+    open suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {}
     open suspend fun willRemove(context: JobContext, result: JobEvent) {}
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,15 +1,16 @@
 package com.liftric.job.queue
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 
 expect class NetworkManager
 
 expect class NetworkListener : AbstractNetworkListener
 abstract class AbstractNetworkListener(
+    val networkManager: NetworkManager,
     val scope: CoroutineScope
 ) {
-    abstract val currentNetworkState: SharedFlow<NetworkState>
+    abstract val currentNetworkState: StateFlow<NetworkState>
     abstract fun observeNetworkState()
     abstract fun stopMonitoring()
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,10 +1,19 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkState
 import kotlinx.coroutines.CoroutineScope
 
+expect class NetworkManager
+
 expect class NetworkListener {
-    actual var networkState: NetworkState
+    var networkState: NetworkState
     val scope: CoroutineScope
     fun observeNetworkState()
+    fun stopMonitoring()
+}
+
+@kotlinx.serialization.Serializable
+enum class NetworkState {
+    NONE,
+    MOBILE,
+    WIFI
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,0 +1,10 @@
+package com.liftric.job.queue
+
+import com.liftric.job.queue.rules.NetworkState
+import kotlinx.coroutines.CoroutineScope
+
+expect class NetworkListener {
+    actual var networkState: NetworkState
+    val scope: CoroutineScope
+    fun observeNetworkState()
+}

--- a/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,14 +1,21 @@
 package com.liftric.job.queue
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharedFlow
 
 expect class NetworkManager
 
-expect class NetworkListener {
-    var networkState: NetworkState
+expect class NetworkListener : AbstractNetworkListener
+abstract class AbstractNetworkListener(
     val scope: CoroutineScope
-    fun observeNetworkState()
-    fun stopMonitoring()
+) {
+    abstract val currentNetworkState: SharedFlow<NetworkState>
+    abstract fun observeNetworkState()
+    abstract fun stopMonitoring()
+
+    fun isNetworkRuleSatisfied(jobInfo: JobInfo, currentNetworkState: NetworkState): Boolean {
+        return currentNetworkState >= jobInfo.minRequiredNetworkState
+    }
 }
 
 @kotlinx.serialization.Serializable

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DelayRule(val duration: Duration = 0.seconds): JobRule() {
-    override suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {
+    override suspend fun willRun(context: JobContext) {
         delay(duration)
     }
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DelayRule(val duration: Duration = 0.seconds): JobRule() {
-    override suspend fun willRun(context: JobContext) {
+    override suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {
         delay(duration)
     }
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/DelayRule.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DelayRule(val duration: Duration = 0.seconds): JobRule() {
-    override suspend fun willRun(context: JobContext) {
+    override suspend fun willRun(jobContext: JobContext) {
         delay(duration)
     }
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -1,6 +1,5 @@
 package com.liftric.job.queue.rules
 
-import com.liftric.job.queue.JobContext
 import com.liftric.job.queue.JobInfo
 import com.liftric.job.queue.JobRule
 import com.liftric.job.queue.NetworkState
@@ -8,15 +7,6 @@ import com.liftric.job.queue.NetworkState
 data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
     override suspend fun mutating(info: JobInfo) {
         info.minRequiredNetworkState = minRequiredNetworkState
-    }
-
-    override suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {
-        if (context.info.minRequiredNetworkState > currentNetworkState) {
-            println("NETWORK RULE: unsatisfied")
-            throw NetworkException("Network requirement not satisfied!")
-        } else {
-            println("NETWORK RULE: satisfied")
-        }
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -4,15 +4,27 @@ import com.liftric.job.queue.JobInfo
 import com.liftric.job.queue.JobRule
 import com.liftric.job.queue.NetworkState
 import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
-data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
+data class NetworkRule(
+    val minRequiredNetworkState: NetworkState,
+    val networkRuleTimeout: Duration
+) : JobRule() {
     override suspend fun mutating(info: JobInfo) {
         info.minRequiredNetworkState = minRequiredNetworkState
+        info.networkRuleTimeout = networkRuleTimeout
     }
 }
 
-fun JobInfo.minRequiredNetwork(networkState: NetworkState): JobInfo {
-    val rule = NetworkRule(networkState)
+fun JobInfo.minRequiredNetwork(
+    networkState: NetworkState,
+    networkRuleTimeout: Duration = 30.seconds
+): JobInfo {
+    val rule = NetworkRule(
+        minRequiredNetworkState = networkState,
+        networkRuleTimeout = networkRuleTimeout
+    )
     rules.add(rule)
     return this
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -1,0 +1,25 @@
+package com.liftric.job.queue.rules
+
+import com.liftric.job.queue.JobInfo
+import com.liftric.job.queue.JobRule
+
+data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
+    override suspend fun mutating(info: JobInfo) {
+        info.minRequiredNetworkState = minRequiredNetworkState
+    }
+}
+
+fun JobInfo.minRequiredNetwork(networkState: NetworkState): JobInfo {
+    val rule = NetworkRule(networkState)
+    rules.add(rule)
+    return this
+}
+
+class NetworkException(message: String) : Exception(message)
+
+@kotlinx.serialization.Serializable
+enum class NetworkState {
+    NONE,
+    MOBILE,
+    WIFI
+}

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -3,6 +3,7 @@ package com.liftric.job.queue.rules
 import com.liftric.job.queue.JobContext
 import com.liftric.job.queue.JobInfo
 import com.liftric.job.queue.JobRule
+import com.liftric.job.queue.NetworkState
 
 data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
     override suspend fun mutating(info: JobInfo) {
@@ -11,10 +12,10 @@ data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
 
     override suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {
         if (context.info.minRequiredNetworkState > currentNetworkState) {
-            println("NETWORK: unsatisfied")
+            println("NETWORK RULE: unsatisfied")
             throw NetworkException("Network requirement not satisfied!")
         } else {
-            println("NETWORK: satisfied")
+            println("NETWORK RULE: satisfied")
         }
     }
 }
@@ -27,9 +28,3 @@ fun JobInfo.minRequiredNetwork(networkState: NetworkState): JobInfo {
 
 class NetworkException(message: String) : Exception(message)
 
-@kotlinx.serialization.Serializable
-enum class NetworkState {
-    NONE,
-    MOBILE,
-    WIFI
-}

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -3,6 +3,7 @@ package com.liftric.job.queue.rules
 import com.liftric.job.queue.JobInfo
 import com.liftric.job.queue.JobRule
 import com.liftric.job.queue.NetworkState
+import kotlinx.coroutines.CancellationException
 
 data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
     override suspend fun mutating(info: JobInfo) {
@@ -16,5 +17,5 @@ fun JobInfo.minRequiredNetwork(networkState: NetworkState): JobInfo {
     return this
 }
 
-class NetworkException(message: String) : Exception(message)
+class NetworkRuleTimeoutException(message: String) : CancellationException(message)
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -1,11 +1,21 @@
 package com.liftric.job.queue.rules
 
+import com.liftric.job.queue.JobContext
 import com.liftric.job.queue.JobInfo
 import com.liftric.job.queue.JobRule
 
 data class NetworkRule(val minRequiredNetworkState: NetworkState) : JobRule() {
     override suspend fun mutating(info: JobInfo) {
         info.minRequiredNetworkState = minRequiredNetworkState
+    }
+
+    override suspend fun willRun(context: JobContext, currentNetworkState: NetworkState) {
+        if (context.info.minRequiredNetworkState > currentNetworkState) {
+            println("NETWORK: unsatisfied")
+            throw NetworkException("Network requirement not satisfied!")
+        } else {
+            println("NETWORK: satisfied")
+        }
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/NetworkRule.kt
@@ -11,9 +11,9 @@ data class NetworkRule(
     val minRequiredNetworkState: NetworkState,
     val networkRuleTimeout: Duration
 ) : JobRule() {
-    override suspend fun mutating(info: JobInfo) {
-        info.minRequiredNetworkState = minRequiredNetworkState
-        info.networkRuleTimeout = networkRuleTimeout
+    override suspend fun mutating(jobInfo: JobInfo) {
+        jobInfo.minRequiredNetworkState = minRequiredNetworkState
+        jobInfo.networkRuleTimeout = networkRuleTimeout
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/PeriodicRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/PeriodicRule.kt
@@ -8,9 +8,9 @@ import kotlin.time.Duration.Companion.seconds
 
 @Serializable
 data class PeriodicRule(val interval: Duration = 0.seconds): JobRule() {
-    override suspend fun willRemove(context: JobContext, result: JobEvent) {
+    override suspend fun willRemove(jobContext: JobContext, result: JobEvent) {
         if (result is JobEvent.DidSucceed) {
-            context.repeat(startTime = Clock.System.now().plus(interval))
+            jobContext.repeat(startTime = Clock.System.now().plus(interval))
         }
     }
 }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/PersistenceRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/PersistenceRule.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PersistenceRule(val shouldPersist: Boolean): JobRule() {
-    override suspend fun mutating(info: JobInfo) {
-        info.shouldPersist = shouldPersist
+    override suspend fun mutating(jobInfo: JobInfo) {
+        jobInfo.shouldPersist = shouldPersist
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/RetryRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/RetryRule.kt
@@ -8,16 +8,16 @@ import kotlin.time.Duration.Companion.seconds
 
 @Serializable
 data class RetryRule(val limit: RetryLimit, val delay: Duration = 0.seconds): JobRule() {
-    override suspend fun willRemove(context: JobContext, result: JobEvent) {
+    override suspend fun willRemove(jobContext: JobContext, result: JobEvent) {
         if (result is JobEvent.DidFail) {
             when (limit) {
                 is RetryLimit.Unlimited ->  {
-                    context.repeat(startTime = Clock.System.now())
+                    jobContext.repeat(startTime = Clock.System.now())
                 }
                 is RetryLimit.Limited -> {
                     if (limit.count > 0) {
-                        val rules = context.info.rules.minus(this).plus(RetryRule(RetryLimit.Limited(limit.count - 1), delay))
-                        context.repeat(info = context.info.copy(rules = rules.toMutableList()), startTime = Clock.System.now().plus(delay))
+                        val rules = jobContext.info.rules.minus(this).plus(RetryRule(RetryLimit.Limited(limit.count - 1), delay))
+                        jobContext.repeat(info = jobContext.info.copy(rules = rules.toMutableList()), startTime = Clock.System.now().plus(delay))
                     }
                 }
             }

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/TimeoutRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/TimeoutRule.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TimeoutRule(val timeout: Duration): JobRule() {
-    override suspend fun mutating(info: JobInfo) {
-        info.jobTimeout = timeout
+    override suspend fun mutating(jobInfo: JobInfo) {
+        jobInfo.jobTimeout = timeout
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/TimeoutRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/TimeoutRule.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TimeoutRule(val timeout: Duration): JobRule() {
     override suspend fun mutating(info: JobInfo) {
-        info.timeout = timeout
+        info.jobTimeout = timeout
     }
 }
 

--- a/src/commonMain/kotlin/com/liftric/job/queue/rules/UniqueRule.kt
+++ b/src/commonMain/kotlin/com/liftric/job/queue/rules/UniqueRule.kt
@@ -5,16 +5,16 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UniqueRule(private val tag: String? = null): JobRule() {
-    override suspend fun mutating(info: JobInfo) {
-        info.tag = tag
+    override suspend fun mutating(jobInfo: JobInfo) {
+        jobInfo.tag = tag
     }
 
-    override suspend fun willSchedule(queue: Queue, context: JobContext) {
+    override suspend fun willSchedule(queue: Queue, jobContext: JobContext) {
         for (item in queue.jobs) {
             if (item.info.tag == tag) {
                 throw Throwable("Job with tag=${item.info.tag} already exists")
             }
-            if (item.id == context.id) {
+            if (item.id == jobContext.id) {
                 throw Throwable("Job with id=${item.id} already exists")
             }
         }

--- a/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -183,7 +183,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
         }
 
         queue.schedule(TestData(id), ::TestTask) {
-            minRequiredNetwork(NetworkState.MOBILE)
+            minRequiredNetwork(NetworkState.NONE, 3.seconds)
         }
 
         println("Network State: ${queue.networkListener.currentNetworkState.value}")
@@ -205,7 +205,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
         }
 
         queue.schedule(TestData(id), ::TestTask) {
-            minRequiredNetwork(NetworkState.WIFI)
+            minRequiredNetwork(NetworkState.WIFI, 3.seconds)
         }
 
         println("Network State: ${queue.networkListener.currentNetworkState.value}")

--- a/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -175,11 +175,10 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
         launch {
             queue.jobEventListener.collect {
                 println("TEST -> JOB INFO: $it")
-                if (it is JobEvent.WillRun) {
-                    return@collect
-                }
-                cancel()
-                assertTrue(it is JobEvent.DidSucceed)
+                if (it is JobEvent.DidCancel || it is JobEvent.DidSucceed) {
+                    cancel()
+                    assertTrue(it is JobEvent.DidSucceed)
+                } else return@collect
             }
         }
 
@@ -187,8 +186,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
             minRequiredNetwork(NetworkState.MOBILE)
         }
 
-        queue.networkListener.networkState = NetworkState.WIFI
-        println("Network State: ${queue.networkListener.networkState}")
+        println("Network State: ${queue.networkListener.currentNetworkState.value}")
 
         queue.start()
     }
@@ -199,11 +197,10 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
         launch {
             queue.jobEventListener.collect {
                 println("TEST -> JOB INFO: $it")
-                if (it is JobEvent.WillRun) {
-                    return@collect
-                }
-                cancel()
-                assertTrue(it is JobEvent.DidFail)
+                if (it is JobEvent.DidCancel || it is JobEvent.DidSucceed) {
+                    cancel()
+                    assertTrue(it is JobEvent.DidCancel)
+                } else return@collect
             }
         }
 
@@ -211,8 +208,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
             minRequiredNetwork(NetworkState.WIFI)
         }
 
-        queue.networkListener.networkState = NetworkState.MOBILE
-        println("Network State: ${queue.networkListener.networkState}")
+        println("Network State: ${queue.networkListener.currentNetworkState.value}")
 
         queue.start()
     }

--- a/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/commonTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -192,7 +192,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
     }
 
     @Test
-    fun testNetworkRuleUnSatisfied() = runBlocking {
+    fun testNetworkRuleUnsatisfied() = runBlocking {
         val id = UUIDFactory.create().toString()
         val job = launch {
             queue.jobEventListener.collect {
@@ -205,7 +205,7 @@ abstract class AbstractJobQueueTests(private val queue: JobQueue) {
             minRequiredNetwork(NetworkState.WIFI)
         }
 
-        queue.networkListener.networkState = NetworkState.NONE
+        queue.networkListener.networkState = NetworkState.MOBILE
         println("Network State: ${queue.networkListener.networkState}")
 
         queue.start()

--- a/src/iosMain/kotlin/com/liftric/job/queue/JobQueue.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/JobQueue.kt
@@ -7,9 +7,11 @@ import platform.Foundation.NSUserDefaults
 actual class JobQueue(
     serializers: SerializersModule = SerializersModule {},
     configuration: Queue.Configuration = Queue.DefaultConfiguration,
+    networkListener: NetworkListener,
     store: JsonStorage = SettingsStorage(NSUserDefaultsSettings(NSUserDefaults("com.liftric.persisted.queue")))
 ) : AbstractJobQueue(
-    serializers,
-    configuration,
-    store
+    serializers = serializers,
+    networkListener = networkListener,
+    configuration = configuration,
+    store = store
 )

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,0 +1,27 @@
+package com.liftric.job.queue
+
+import com.liftric.job.queue.rules.NetworkState
+import dev.tmapps.konnection.Konnection
+import dev.tmapps.konnection.NetworkConnection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+actual class NetworkListener(
+    actual var networkState: NetworkState = NetworkState.NONE,
+    actual val scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
+) {
+    actual fun observeNetworkState() {
+        Konnection()
+            .observeNetworkConnection()
+            .onEach { networkConnection ->
+                networkState = when (networkConnection) {
+                    NetworkConnection.WIFI -> NetworkState.WIFI
+                    NetworkConnection.MOBILE -> NetworkState.MOBILE
+                    null -> NetworkState.NONE
+                }
+            }
+            .launchIn(scope)
+    }
+}

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -2,22 +2,22 @@ package com.liftric.job.queue
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 actual class NetworkListener(
+    networkManager: NetworkManager,
     scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
 ) : AbstractNetworkListener(
+    networkManager = networkManager,
     scope = scope
 ) {
-    private val networkManager = NetworkManager()
-
-    private val _currentNetworkState = MutableSharedFlow<NetworkState>(replay = 1)
-    override val currentNetworkState: SharedFlow<NetworkState>
-        get() = _currentNetworkState.asSharedFlow()
+    private val _currentNetworkState = MutableStateFlow(NetworkState.NONE)
+    override val currentNetworkState: StateFlow<NetworkState>
+        get() = _currentNetworkState.asStateFlow()
 
     override fun observeNetworkState() {
         networkManager.startMonitoring()

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -19,22 +19,19 @@ actual class NetworkListener(
     override val currentNetworkState: StateFlow<NetworkState>
         get() = _currentNetworkState.asStateFlow()
 
+    private var job: kotlinx.coroutines.Job? = null
+
     override fun observeNetworkState() {
-        networkManager.startMonitoring()
-        scope.launch {
+        job = scope.launch {
+            networkManager.startMonitoring()
             networkManager.network.collectLatest { currentNetworkState ->
-                _currentNetworkState.emit(
-                    when (currentNetworkState) {
-                        NetworkState.NONE -> NetworkState.NONE
-                        NetworkState.MOBILE -> NetworkState.MOBILE
-                        NetworkState.WIFI -> NetworkState.WIFI
-                    }
-                )
+                _currentNetworkState.emit(currentNetworkState)
             }
         }
     }
 
     override fun stopMonitoring() {
         networkManager.stopMonitoring()
+        job?.cancel()
     }
 }

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkListener.kt
@@ -1,27 +1,30 @@
 package com.liftric.job.queue
 
-import com.liftric.job.queue.rules.NetworkState
-import dev.tmapps.konnection.Konnection
-import dev.tmapps.konnection.NetworkConnection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 actual class NetworkListener(
     actual var networkState: NetworkState = NetworkState.NONE,
     actual val scope: CoroutineScope = CoroutineScope(context = Dispatchers.Default)
 ) {
+    private val networkManager = NetworkManager()
+
     actual fun observeNetworkState() {
-        Konnection()
-            .observeNetworkConnection()
-            .onEach { networkConnection ->
-                networkState = when (networkConnection) {
-                    NetworkConnection.WIFI -> NetworkState.WIFI
-                    NetworkConnection.MOBILE -> NetworkState.MOBILE
-                    null -> NetworkState.NONE
+        networkManager.startMonitoring()
+        scope.launch {
+            networkManager.network.collectLatest { currentNetworkState ->
+                networkState = when (currentNetworkState) {
+                    NetworkState.NONE -> NetworkState.NONE
+                    NetworkState.MOBILE -> NetworkState.MOBILE
+                    NetworkState.WIFI -> NetworkState.WIFI
                 }
             }
-            .launchIn(scope)
+        }
+    }
+
+    actual fun stopMonitoring() {
+        networkManager.stopMonitoring()
     }
 }

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkManager.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkManager.kt
@@ -1,0 +1,60 @@
+package com.liftric.job.queue
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import platform.Network.*
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+import platform.darwin.dispatch_queue_attr_make_with_qos_class
+import platform.darwin.dispatch_queue_create
+import platform.posix.QOS_CLASS_UTILITY
+
+class NetworkManager {
+    private val networkChannel = Channel<NetworkState>(Channel.UNLIMITED)
+    val network: Flow<NetworkState> = networkChannel.receiveAsFlow()
+
+    private val networkMonitor = object : nw_path_monitor_update_handler_t {
+        override fun invoke(network: nw_path_t) {
+            checkReachability(network)
+        }
+
+    }
+    private val nwPathMonitor: nw_path_monitor_t = nw_path_monitor_create().apply {
+        val queue = dispatch_queue_create(
+            "com.liftric.job.queue",
+            dispatch_queue_attr_make_with_qos_class(
+                null,
+                QOS_CLASS_UTILITY,
+                DISPATCH_QUEUE_PRIORITY_DEFAULT
+            )
+        )
+        nw_path_monitor_set_queue(
+            this,
+            queue
+        )
+        nw_path_monitor_set_update_handler(this, networkMonitor)
+    }
+
+    fun startMonitoring() {
+        nw_path_monitor_start(nwPathMonitor)
+    }
+
+    fun stopMonitoring() {
+        nw_path_monitor_cancel(nwPathMonitor)
+    }
+
+    private fun checkReachability(network: nw_path_t) {
+        when (nw_path_get_status(network)) {
+            nw_path_status_satisfied -> {
+                if (nw_path_uses_interface_type(network, nw_interface_type_wifi)) {
+                    networkChannel.trySend(NetworkState.WIFI)
+                } else if (nw_path_uses_interface_type(network, nw_interface_type_cellular)) {
+                    networkChannel.trySend(NetworkState.MOBILE)
+                }
+            }
+            nw_path_status_unsatisfied -> {
+                networkChannel.trySend(NetworkState.NONE)
+            }
+        }
+    }
+}

--- a/src/iosMain/kotlin/com/liftric/job/queue/NetworkManager.kt
+++ b/src/iosMain/kotlin/com/liftric/job/queue/NetworkManager.kt
@@ -9,7 +9,7 @@ import platform.darwin.dispatch_queue_attr_make_with_qos_class
 import platform.darwin.dispatch_queue_create
 import platform.posix.QOS_CLASS_UTILITY
 
-class NetworkManager {
+actual class NetworkManager {
     private val networkChannel = Channel<NetworkState>(Channel.UNLIMITED)
     val network: Flow<NetworkState> = networkChannel.receiveAsFlow()
 

--- a/src/iosTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/iosTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -11,6 +11,6 @@ actual class JobQueueTests : AbstractJobQueueTests(
             }
         },
         store = MapStorage(),
-        networkListener = NetworkListener()
+        networkListener = NetworkListener(networkManager = NetworkManager())
     )
 )

--- a/src/iosTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
+++ b/src/iosTest/kotlin/com/liftric/job/queue/JobQueueTests.kt
@@ -3,11 +3,14 @@ package com.liftric.job.queue
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 
-actual class JobQueueTests: AbstractJobQueueTests(JobQueue(
-    serializers = SerializersModule {
-        polymorphic(Task::class) {
-            subclass(TestTask::class, TestTask.serializer())
-        }
-    },
-    store = MapStorage()
-))
+actual class JobQueueTests : AbstractJobQueueTests(
+    JobQueue(
+        serializers = SerializersModule {
+            polymorphic(Task::class) {
+                subclass(TestTask::class, TestTask.serializer())
+            }
+        },
+        store = MapStorage(),
+        networkListener = NetworkListener()
+    )
+)


### PR DESCRIPTION
The network rule requires two parameters: `NetworkState` and `networkTimeoutDuration`. The NetworkState parameter specifies the desired state of the network that needs to be satisfied, while the networkTimeoutDuration parameter specifies the duration to observe changes in the network state.

The network rule follows the flow outlined below:
1. If the network state is not satisfied during `networkTimeoutDuration`:
    * `NetworkRuleTimeout` will be emitted.
    * `DidCancel` will be emitted.
2. If the network state is satisfied during networkTimeoutDuration:
    * `NetworkRuleSatisfied` will be emitted and `NetworkRuleTimeout@` scope will be cancelled.
    * `WillRun` will be emitted.
    * If the job is completed within `jobTimeout`:
       *  `result` will be emitted which can be one of three events: `DidSucceed`, `DidFail`, `DidFailOnRemove`
       * Otherwise `JobTimeout` and `DidCancel` will be emitted.

Changes in the code:
- define network states (WIFI, MOBILE, NONE)
- observe changes in the network state
- move `withTimeout()` to `JobQueue`
- add more tests
- some clean-up